### PR TITLE
Fix to push snapshot in the correct directory

### DIFF
--- a/addons/storyshots/storyshots-core/src/Stories2SnapsConverter.ts
+++ b/addons/storyshots/storyshots-core/src/Stories2SnapsConverter.ts
@@ -29,7 +29,7 @@ export class Stories2SnapsConverter {
     const { dir, name } = path.parse(fileName);
     const { snapshotsDirName, snapshotExtension } = this.options;
 
-    return path.format({ dir: path.join(dir, snapshotsDirName), name, ext: snapshotExtension });
+    return path.format({ dir: path.join('..', dir, snapshotsDirName), name, ext: snapshotExtension });
   }
 
   getSnapshotFileName(context: { fileName?: string; kind: any }) {


### PR DESCRIPTION
Currently storyshots Stories2SnapsConverter uses the src directory as working directory and puts the snapshots with their full path inside with a resulting src/src/... directory structure. This seems to be wrong.

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
